### PR TITLE
Update `Repo.prepare_query` to check if query explicitly includes soft deleted records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2020-05-08
+
+- Add logic to `Ecto.SoftDelete.Repo.prepare_query` to respect where clauses that explicitly include records where deleted_at is not nil 
+
 ## [2.0.0] - 2020-05-06
 
 - Exclude soft deleted records by default in `Ecto.SoftDelete.Repo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.1] - 2020-05-08
 
-- Add logic to `Ecto.SoftDelete.Repo.prepare_query` to respect where clauses that explicitly include records where deleted_at is not nil 
+- Add logic to `Ecto.SoftDelete.Repo.prepare_query` to respect `where` clauses that explicitly include records where deleted_at is not nil 
 
 ## [2.0.0] - 2020-05-06
 

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -89,7 +89,9 @@ defmodule Ecto.SoftDelete.Repo do
         end
       end
 
-      defp has_include_deleted_at_clause?(%{wheres: wheres}) do
+      # Checks the query to see if it contains a where not is_nil(deleted_at)
+      # if it does, we want to be sure that it we dont exclude soft deleted records
+      defp has_include_deleted_at_clause?(%Ecto.Query{wheres: wheres}) do
         Enum.find(wheres, fn %{expr: expr} ->
           expr == {:not, [], [{:is_nil, [], [{{:., [], [{:&, [], [0]}, :deleted_at]}, [], []}]}]}
         end)

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -90,7 +90,7 @@ defmodule Ecto.SoftDelete.Repo do
       end
 
       # Checks the query to see if it contains a where not is_nil(deleted_at)
-      # if it does, we want to be sure that it we don't exclude soft deleted records
+      # if it does, we want to be sure that we don't exclude soft deleted records
       defp has_include_deleted_at_clause?(%Ecto.Query{wheres: wheres}) do
         Enum.any?(wheres, fn %{expr: expr} ->
           expr == {:not, [], [{:is_nil, [], [{{:., [], [{:&, [], [0]}, :deleted_at]}, [], []}]}]}

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -90,7 +90,7 @@ defmodule Ecto.SoftDelete.Repo do
       end
 
       # Checks the query to see if it contains a where not is_nil(deleted_at)
-      # if it does, we want to be sure that it we dont exclude soft deleted records
+      # if it does, we want to be sure that it we don't exclude soft deleted records
       defp has_include_deleted_at_clause?(%Ecto.Query{wheres: wheres}) do
         Enum.any?(wheres, fn %{expr: expr} ->
           expr == {:not, [], [{:is_nil, [], [{{:., [], [{:&, [], [0]}, :deleted_at]}, [], []}]}]}

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -92,7 +92,7 @@ defmodule Ecto.SoftDelete.Repo do
       # Checks the query to see if it contains a where not is_nil(deleted_at)
       # if it does, we want to be sure that it we dont exclude soft deleted records
       defp has_include_deleted_at_clause?(%Ecto.Query{wheres: wheres}) do
-        Enum.find(wheres, fn %{expr: expr} ->
+        Enum.any?(wheres, fn %{expr: expr} ->
           expr == {:not, [], [{:is_nil, [], [{{:., [], [{:&, [], [0]}, :deleted_at]}, [], []}]}]}
         end)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoSoftDelete.Mixfile do
   def project do
     [
       app: :ecto_soft_delete,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.9.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Description:
- Some queries explicitly include deleted at records with something like `where not is_nil(deleted_at)`.
- This was getting overriden by `prepare_query`
- Ideally this could be addressed by passing the `with_deleted` option to `Repo.all` or the like
- BUT in some cases these queries were using scrivener to do `Repo.paginate`, and scrivener does not allow you to pass options