### PR TITLE
Prevent warning when using newer versions of elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoSoftDelete.Mixfile do
     [
       app: :ecto_soft_delete,
       version: "2.0.1",
-      elixir: "~> 1.9.4",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This prevents the following warning when using Elixir 1.10.x

```
==> ecto_soft_delete
warning: the dependency :ecto_soft_delete requires Elixir "~> 1.9.4" but you are running on v1.10.4
```