### PR TITLE
Include soft_deletable? check in with_undeleted function

### DIFF
--- a/lib/ecto/soft_delete_query.ex
+++ b/lib/ecto/soft_delete_query.ex
@@ -25,16 +25,13 @@ defmodule Ecto.SoftDelete.Query do
   end
 
   @doc """
-  Determines if a given Ecto query is soft deletable.
+  Returns `true` if the query is soft deletable, `false` otherwise.
 
-  ### Parameters
+      query = from(u in User, select: u)
+      |> soft_deletable?
 
-      - `query`: An Ecto query struct.
-
-  ### Returns
-
-      - `true` if the query is soft deletable, `false` otherwise.
   """
+  @spec soft_deletable?(Ecto.Queryable.t) :: boolean()
   def soft_deletable?(query) do
     schema_module = get_schema_module(query)
     fields = if schema_module, do: schema_module.__schema__(:fields), else: []

--- a/lib/ecto/soft_delete_query.ex
+++ b/lib/ecto/soft_delete_query.ex
@@ -36,15 +36,14 @@ defmodule Ecto.SoftDelete.Query do
       - `true` if the query is soft deletable, `false` otherwise.
   """
   def soft_deletable?(query) do
-    schema_module = get_schema_module_from_query(query)
+    schema_module = get_schema_module(query)
     fields = if schema_module, do: schema_module.__schema__(:fields), else: []
 
     Enum.member?(fields, :deleted_at)
   end
 
-  defp get_schema_module_from_query(%Ecto.Query{from: %{source: {_name, module}}}) do
-    module
-  end
-
-  defp get_schema_module_from_query(_), do: nil
+  defp get_schema_module({_raw_schema, module}) when not is_nil(module), do: module
+  defp get_schema_module(%Ecto.Query{from: %{source: source}}), do: get_schema_module(source)
+  defp get_schema_module(%Ecto.SubQuery{query: query}), do: get_schema_module(query)
+  defp get_schema_module(_), do: nil
 end


### PR DESCRIPTION
This MR includes the following changes:

- Include `soft_deletable?` check in `with_undeleted` function to filter only the records that have a `deleted_at` field.
- Add support for Ecto.SubQuery in `get_schema_module` function to correctly identify the schema of a subquery.
- Adds tests for the `with_undeleted` and `soft_deletable?` to ensure proper functionality.

This MR improves the ability to handle soft deletion in the application and increases the test coverage for these functions.