### PR TITLE
fix misspelling in dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-dist: zenial
+dist: xenial
 elixir:
   - 1.9.4
 otp_release:


### PR DESCRIPTION
A PR to fix spelling Xenial as Zenial in the travis config. 