### PR TITLE
engineering#245 - change push conditions to require a tag AND master branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Publish
 on:
   push:
     tags: [ 'v*.*.*' ]
-    branches: master
 
 env:
   OTP_VERSION_SPEC: "21.1"
@@ -14,6 +13,7 @@ jobs:
     uses: ./.github/workflows/test.yml
   publish:
     needs: test
+    if: ${{ github.ref_name == 'master' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Response to failed publish:
https://github.com/revelrylabs/ecto_soft_delete/actions/runs/8571557508/job/23492117202

The error indicates we're trying to re-publish an existing version after the hour window of published version update availability. Perhaps we can open a https://github.com/hexpm/hexpm PR that checks to see if attempts to publish packages are from over x amount of time after a publish, and if so, displays separate or even additional error copy (e.g "further updates to this package will require a package version update")