### PR TITLE
Allow Elixir versions 1.11+ instead of requiring 1.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: "22"
-            elixir: "1.9"
+          - otp: "21"
+            elixir: "1.11"
           - otp: "26"
             elixir: "1.16"
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Test
 on: [push, workflow_call]
 
 env:
-  OTP_VERSION_SPEC: "25.3"
-  ELIXIR_VERSION_SPEC: "1.13.4"
   MIX_ENV: test
   PGUSER: postgres
   POSTGRES_USER: postgres
@@ -14,7 +12,15 @@ env:
 
 jobs:
   test:
+    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - otp: "22"
+            elixir: "1.9"
+          - otp: "26"
+            elixir: "1.16"
     services:
       postgres:
         env:
@@ -27,17 +33,18 @@ jobs:
           --health-timeout 5s --health-retries 5
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: ${{ env.OTP_VERSION_SPEC }}
-        elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
 
-    - name: Run Tests
-      run: |
-        mix deps.get
-        cp config/test.exs.GH_actions config/test.exs
-        mix ecto.create
-        mix test
+      - name: Run Tests
+        run: |
+          mix deps.get
+          cp config/test.exs.GH_actions config/test.exs
+          mix ecto.create
+          mix test

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoSoftDelete.Mixfile do
     [
       app: :ecto_soft_delete,
       version: "2.0.3",
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoSoftDelete.Mixfile do
     [
       app: :ecto_soft_delete,
       version: "2.0.3",
-      elixir: "~> 1.13.4",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Thanks to @nilsojes for pointing out the mistake in the previous release!

- Allow any Elixir version from 1.11 on
- Run CI agains the min supported version as well as the most recent (tested) version