### PR TITLE
chore: release version 2.0.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: [ 'v*.*.*' ]
-    branches: master
+    tags: ["v*.*.*"]
 
 env:
   OTP_VERSION_SPEC: "25.3"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoSoftDelete.Mixfile do
   def project do
     [
       app: :ecto_soft_delete,
-      version: "2.0.3",
+      version: "2.0.4",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Also updating the publish workflow to not run on every push to `master`. We'll create a tag `v2.0.4` to publish to Hex