### PR TITLE
Add escape hatch for when one doesn't want `prepare_query`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Import `Ecto.SoftDelete.Schema` into your Schema module, then add `soft_delete_s
   end
 ```
 
+If you want to make sure auto-filtering is disabled for a schema, set the `auto_exclude_from_queries?` option to false
+
+```elixir
+  defmodule User do
+    use Ecto.Schema
+    import Ecto.SoftDelete.Schema
+
+    schema "users" do
+      field :email,           :string
+      soft_delete_schema(auto_exclude_from_queries?: false)
+    end
+  end
+```
+
 ### Queries
 
 To query for items that have not been deleted, use `with_undeleted(query)` which will filter out deleted items using the `deleted_at` column produced by the previous 2 steps
@@ -71,6 +85,9 @@ query = from(u in User, select: u)
 
 results = Repo.all(query, with_deleted: true)
 ```
+
+> [!IMPORTANT]
+> This only works for the topmost schema. If using `Ecto.SoftDelete.Repo`, rows fetched through associations (such as when using `Repo.preload/2`) will still be filtered.
 
 ## Repos
 
@@ -99,6 +116,8 @@ end
 post = Repo.get!(Post, 42)
 struct = Repo.soft_delete!(post)
 ```
+
+`Ecto.SoftDelete.Repo` will also intercept all queries made with the repo and automatically add a clause to filter out soft-deleted rows.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Import `Ecto.SoftDelete.Schema` into your Schema module, then add `soft_delete_s
     import Ecto.SoftDelete.Schema
 
     schema "users" do
-      field :email,           :string
+      field :email, :string
       soft_delete_schema()
     end
   end
@@ -55,7 +55,7 @@ If you want to make sure auto-filtering is disabled for a schema, set the `auto_
     import Ecto.SoftDelete.Schema
 
     schema "users" do
-      field :email,           :string
+      field :email, :string
       soft_delete_schema(auto_exclude_from_queries?: false)
     end
   end

--- a/lib/ecto/soft_delete_query.ex
+++ b/lib/ecto/soft_delete_query.ex
@@ -39,6 +39,17 @@ defmodule Ecto.SoftDelete.Query do
     Enum.member?(fields, :deleted_at)
   end
 
+  @doc"""
+  Returns `true` if the schema is not flagged to skip auto-filtering
+  """
+  @spec auto_include_deleted_at_clause?(Ecto.Queriable.t) :: boolean()
+  def auto_include_deleted_at_clause?(query) do
+    schema_module = get_schema_module(query)
+
+   !Kernel.function_exported?(schema_module, :skip_soft_delete_prepare_query?, 0) ||
+      !schema_module.skip_soft_delete_prepare_query?()
+  end
+
   defp get_schema_module({_raw_schema, module}) when not is_nil(module), do: module
   defp get_schema_module(%Ecto.Query{from: %{source: source}}), do: get_schema_module(source)
   defp get_schema_module(%Ecto.SubQuery{query: query}), do: get_schema_module(query)

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -78,7 +78,13 @@ defmodule Ecto.SoftDelete.Repo do
       NOTE: will not exclude soft deleted records if :with_deleted option passed as true
       """
       def prepare_query(_operation, query, opts) do
-        if has_include_deleted_at_clause?(query) || opts[:with_deleted] || !soft_deletable?(query) do
+        skip_deleted_at_clause? =
+          has_include_deleted_at_clause?(query) ||
+            opts[:with_deleted] ||
+            !soft_deletable?(query) ||
+            !auto_include_deleted_at_clause?(query)
+
+        if skip_deleted_at_clause? do
           {query, opts}
         else
           query = from(x in query, where: is_nil(x.deleted_at))

--- a/lib/ecto/soft_delete_schema.ex
+++ b/lib/ecto/soft_delete_schema.ex
@@ -17,21 +17,21 @@ defmodule Ecto.SoftDelete.Schema do
       end
 
   Options:
-  - `:skip_prepare_query?` - If true, Ecto.SoftDelete.Repo won't automatically
-  add the necessary clause to filter aout soft-deleted rows. See
-  `Ecto.SoftDelete.Repo.prepare_query` for more info. Defaults to `false`.
+  - `:auto_exclude_from_queries?` - If false, Ecto.SoftDelete.Repo won't
+  automatically add the necessary clause to filter aout soft-deleted rows. See
+  `Ecto.SoftDelete.Repo.prepare_query` for more info. Defaults to `true`.
 
   """
   defmacro soft_delete_schema(opts \\ []) do
     filter_tag_definition =
-      if Keyword.get(opts, :skip_prepare_query?, false) do
+      unless Keyword.get(opts, :auto_exclude_from_queries?, true) do
         quote do
           def skip_soft_delete_prepare_query?, do: true
         end
       end
 
     quote do
-      field :deleted_at, :utc_datetime_usec
+      field(:deleted_at, :utc_datetime_usec)
       unquote(filter_tag_definition)
     end
   end

--- a/lib/ecto/soft_delete_schema.ex
+++ b/lib/ecto/soft_delete_schema.ex
@@ -16,10 +16,23 @@ defmodule Ecto.SoftDelete.Schema do
         end
       end
 
+  Options:
+  - `:skip_prepare_query?` - If true, Ecto.SoftDelete.Repo won't automatically
+  add the necessary clause to filter aout soft-deleted rows. See
+  `Ecto.SoftDelete.Repo.prepare_query` for more info. Defaults to `false`.
+
   """
-  defmacro soft_delete_schema do
+  defmacro soft_delete_schema(opts \\ []) do
+    filter_tag_definition =
+      if Keyword.get(opts, :skip_prepare_query?, false) do
+        quote do
+          def skip_soft_delete_prepare_query?, do: true
+        end
+      end
+
     quote do
       field :deleted_at, :utc_datetime_usec
+      unquote(filter_tag_definition)
     end
   end
 end

--- a/lib/ecto/soft_delete_schema.ex
+++ b/lib/ecto/soft_delete_schema.ex
@@ -11,14 +11,14 @@ defmodule Ecto.SoftDelete.Schema do
         import Ecto.SoftDelete.Schema
 
         schema "users" do
-          field :email,           :string
+          field :email, :string
           soft_delete_schema()
         end
       end
 
   Options:
   - `:auto_exclude_from_queries?` - If false, Ecto.SoftDelete.Repo won't
-  automatically add the necessary clause to filter aout soft-deleted rows. See
+  automatically add the necessary clause to filter out soft-deleted rows. See
   `Ecto.SoftDelete.Repo.prepare_query` for more info. Defaults to `true`.
 
   """

--- a/test/soft_delete_repo_test.exs
+++ b/test/soft_delete_repo_test.exs
@@ -13,6 +13,16 @@ defmodule Ecto.SoftDelete.Repo.Test do
     end
   end
 
+  defmodule UserWithSkipPrepareQuery do
+    use Ecto.Schema
+    import Ecto.SoftDelete.Schema
+
+    schema "users" do
+      field(:email, :string)
+      soft_delete_schema(skip_prepare_query?: true)
+    end
+  end
+
   defmodule Nondeletable do
     use Ecto.Schema
 
@@ -127,6 +137,17 @@ defmodule Ecto.SoftDelete.Repo.Test do
         |> Repo.all()
 
       refute Enum.member?(results, user)
+      assert Enum.member?(results, soft_deleted_user)
+    end
+
+    test "includes soft deleted records if `skip_prepare_query?` is true" do
+      user = Repo.insert!(%UserWithSkipPrepareQuery{email: "test0@example.com"})
+      soft_deleted_user =
+        Repo.insert!(%UserWithSkipPrepareQuery{email: "deleted@example.com", deleted_at: DateTime.utc_now()})
+
+      results = UserWithSkipPrepareQuery |> Repo.all()
+
+      assert Enum.member?(results, user)
       assert Enum.member?(results, soft_deleted_user)
     end
 

--- a/test/soft_delete_repo_test.exs
+++ b/test/soft_delete_repo_test.exs
@@ -19,7 +19,7 @@ defmodule Ecto.SoftDelete.Repo.Test do
 
     schema "users" do
       field(:email, :string)
-      soft_delete_schema(skip_prepare_query?: true)
+      soft_delete_schema(auto_exclude_from_queries?: false)
     end
   end
 
@@ -140,10 +140,14 @@ defmodule Ecto.SoftDelete.Repo.Test do
       assert Enum.member?(results, soft_deleted_user)
     end
 
-    test "includes soft deleted records if `skip_prepare_query?` is true" do
+    test "includes soft deleted records if `auto_exclude_from_queries?` is false" do
       user = Repo.insert!(%UserWithSkipPrepareQuery{email: "test0@example.com"})
+
       soft_deleted_user =
-        Repo.insert!(%UserWithSkipPrepareQuery{email: "deleted@example.com", deleted_at: DateTime.utc_now()})
+        Repo.insert!(%UserWithSkipPrepareQuery{
+          email: "deleted@example.com",
+          deleted_at: DateTime.utc_now()
+        })
 
       results = UserWithSkipPrepareQuery |> Repo.all()
 


### PR DESCRIPTION
Adds a way of configuring specific schemas to not get `deleted_at` clauses automatically.

This is especially useful for issues like #100 