### PR TITLE
fix: Erroneous where clause on subquery w/ un-selected  'deleted_at' #185

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ erl_crash.dump
 *.ez
 
 /.elixir_ls
+/.lexical

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -101,7 +101,7 @@ defmodule Ecto.SoftDelete.Repo do
 
       defp filter_soft_deleted(%Ecto.SubQuery{query: query} = sub) do
         if Ecto.SoftDelete.Query.soft_deletable?(query) do
-          from(x in query, where: is_nil(x.deleted_at)) |> subquery()
+          %{sub | query: from(x in query, where: is_nil(x.deleted_at))}
         else
           sub
         end

--- a/test/soft_delete_repo_test.exs
+++ b/test/soft_delete_repo_test.exs
@@ -115,6 +115,16 @@ defmodule Ecto.SoftDelete.Repo.Test do
       assert Enum.member?(results, soft_deleted_user)
     end
 
+    test "handles subquery that does not expose deleted_at as 'main' schema" do
+      Repo.insert!(%User{email: "test0@example.com"})
+      Repo.insert!(%Nondeletable{value: "stuff"})
+
+      subq = User |> where([u], u.email == "test0@example.com") |> select([u], %{id: u.id, email: u.email})
+      query = subquery(subq) |> join(:left, [u], nondel in Nondeletable, on: u.id == nondel.id)
+
+      Repo.all(query)
+    end
+
     test "includes soft deleted records if where not is_nil(deleted_at) clause is present" do
       user = Repo.insert!(%User{email: "test0@example.com"})
 


### PR DESCRIPTION
Connects to #185 

- [X] Test case illustrating the example
- [ ] Actually fix it 😄 

### Notes
- I tried several iterations to arrive at this repro, and the key seems to be that the subquery is the "main" table / schema of the outer query, causing the [get_schema_module](https://github.com/revelrylabs/ecto_soft_delete/blob/master/lib/ecto/soft_delete_query.ex#L42-L45) call to recurse down and add the where clause to the outer query. It seems that what we really want instead is for the clause to be added to the _subquery itself_ not to the outer query.