### PR TITLE
Add Options parameter to soft delete functions (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ post = Repo.get!(Post, 42)
 struct = Repo.soft_delete!(post)
 ```
 
+### Using Options with Soft Delete Functions
+All soft delete functions support the same options as their Ecto counterparts:
+
+```elixir
+# With schema prefix for multi-tenant databases
+Repo.soft_delete(post, prefix: "tenant_abc")
+Repo.soft_delete!(post, prefix: "tenant_abc")
+Repo.soft_delete_all(Post, prefix: "tenant_abc")
+```
+This allows for seamless integration with features like PostgreSQL schema prefixes for multi-tenancy.
+
 `Ecto.SoftDelete.Repo` will also intercept all queries made with the repo and automatically add a clause to filter out soft-deleted rows.
 
 ## Installation

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -19,7 +19,7 @@ defmodule Ecto.SoftDelete.Repo do
   unless a `select` is supplied in the update query.
 
   ## Options
-  
+
   All options supported by `c:Ecto.Repo.update_all/3` can be used.
 
   ## Examples
@@ -89,12 +89,10 @@ defmodule Ecto.SoftDelete.Repo do
         changeset = Ecto.Changeset.change(struct_or_changeset, deleted_at: DateTime.utc_now())
 
         case opts do
-          # Original behavior without options
           [] ->
             changesetForUpdate = changeset
             __MODULE__.update(changesetForUpdate)
 
-          # New behavior with options
           _ ->
             __MODULE__.update(changeset, opts)
         end
@@ -107,6 +105,7 @@ defmodule Ecto.SoftDelete.Repo do
           [] ->
             changesetForUpdate = changeset
             __MODULE__.update!(changesetForUpdate)
+
           _ ->
             __MODULE__.update!(changeset, opts)
         end

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -63,7 +63,7 @@ defmodule Ecto.SoftDelete.Repo do
             ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
 
   @doc """
-  Same as `c:soft_delete/1` but returns the struct or raises if the changeset is invalid.
+  Same as `c:soft_delete/2` but returns the struct or raises if the changeset is invalid.
   """
   @callback soft_delete!(
               struct_or_changeset :: Ecto.Schema.t() | Ecto.Changeset.t(),

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -77,38 +77,18 @@ defmodule Ecto.SoftDelete.Repo do
 
       def soft_delete_all(queryable, opts \\ []) do
         set_expr = [set: [deleted_at: DateTime.utc_now()]]
-
-        case opts do
-          [] -> update_all(queryable, set_expr)
-          _ -> update_all(queryable, set_expr, opts)
-        end
+        update_all(queryable, set_expr, opts)
       end
 
       # Define soft_delete and soft_delete! with options
       def soft_delete(struct_or_changeset, opts \\ []) do
         changeset = Ecto.Changeset.change(struct_or_changeset, deleted_at: DateTime.utc_now())
-
-        case opts do
-          [] ->
-            changesetForUpdate = changeset
-            __MODULE__.update(changesetForUpdate)
-
-          _ ->
-            __MODULE__.update(changeset, opts)
-        end
+        __MODULE__.update(changeset, opts)
       end
 
       def soft_delete!(struct_or_changeset, opts \\ []) do
         changeset = Ecto.Changeset.change(struct_or_changeset, deleted_at: DateTime.utc_now())
-
-        case opts do
-          [] ->
-            changesetForUpdate = changeset
-            __MODULE__.update!(changesetForUpdate)
-
-          _ ->
-            __MODULE__.update!(changeset, opts)
-        end
+        __MODULE__.update!(changeset, opts)
       end
 
       @doc """

--- a/lib/ecto/soft_delete_repo.ex
+++ b/lib/ecto/soft_delete_repo.ex
@@ -82,13 +82,15 @@ defmodule Ecto.SoftDelete.Repo do
 
       # Define soft_delete and soft_delete! with options
       def soft_delete(struct_or_changeset, opts \\ []) do
-        changeset = Ecto.Changeset.change(struct_or_changeset, deleted_at: DateTime.utc_now())
-        __MODULE__.update(changeset, opts)
+        struct_or_changeset
+        |> Ecto.Changeset.change(deleted_at: DateTime.utc_now())
+        |> __MODULE__.update(opts)
       end
 
       def soft_delete!(struct_or_changeset, opts \\ []) do
-        changeset = Ecto.Changeset.change(struct_or_changeset, deleted_at: DateTime.utc_now())
-        __MODULE__.update!(changeset, opts)
+        struct_or_changeset
+        |> Ecto.Changeset.change(deleted_at: DateTime.utc_now())
+        |> __MODULE__.update!(opts)
       end
 
       @doc """

--- a/test/soft_delete_repo_test.exs
+++ b/test/soft_delete_repo_test.exs
@@ -55,6 +55,18 @@ defmodule Ecto.SoftDelete.Repo.Test do
     end
   end
 
+  describe "soft_delete!/2 with options" do
+    test "should soft delete the queryable and pass options to update!" do
+      user = Repo.insert!(%User{email: "test0@example.com"})
+
+      # Test with empty options list
+      assert %User{} = Repo.soft_delete!(user, [])
+
+      assert %DateTime{} =
+               Repo.get_by!(User, [email: "test0@example.com"], with_deleted: true).deleted_at
+    end
+  end
+
   describe "soft_delete/1" do
     test "should soft delete the queryable" do
       user = Repo.insert!(%User{email: "test0@example.com"})
@@ -72,6 +84,18 @@ defmodule Ecto.SoftDelete.Repo.Test do
       assert_raise Ecto.StaleEntryError, fn ->
         Repo.soft_delete(user)
       end
+    end
+  end
+
+  describe "soft_delete/2 with options" do
+    test "should soft delete the queryable and pass options to update" do
+      user = Repo.insert!(%User{email: "test0@example.com"})
+
+      # Test with empty options list
+      assert {:ok, %User{}} = Repo.soft_delete(user, [])
+
+      assert %DateTime{} =
+               Repo.get_by!(User, [email: "test0@example.com"], with_deleted: true).deleted_at
     end
   end
 
@@ -97,6 +121,24 @@ defmodule Ecto.SoftDelete.Repo.Test do
 
     test "when no results are found" do
       assert Repo.soft_delete_all(User) == {0, nil}
+    end
+  end
+
+  describe "soft_delete_all/2 with options" do
+    test "soft deletes the query and passes options to update_all" do
+      Repo.insert!(%User{email: "test0@example.com"})
+      Repo.insert!(%User{email: "test1@example.com"})
+
+      # Test with empty options list
+      assert Repo.soft_delete_all(User, []) == {2, nil}
+
+      assert User |> Repo.all(with_deleted: true) |> length() == 2
+
+      assert %DateTime{} =
+               Repo.get_by!(User, [email: "test0@example.com"], with_deleted: true).deleted_at
+
+      assert %DateTime{} =
+               Repo.get_by!(User, [email: "test1@example.com"], with_deleted: true).deleted_at
     end
   end
 

--- a/test/soft_delete_repo_test.exs
+++ b/test/soft_delete_repo_test.exs
@@ -2,6 +2,7 @@ defmodule Ecto.SoftDelete.Repo.Test do
   use ExUnit.Case
   alias Ecto.SoftDelete.Test.Repo
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   defmodule User do
     use Ecto.Schema
@@ -139,6 +140,18 @@ defmodule Ecto.SoftDelete.Repo.Test do
 
       assert %DateTime{} =
                Repo.get_by!(User, [email: "test1@example.com"], with_deleted: true).deleted_at
+    end
+
+    test "soft deletes with log option" do
+      Repo.insert!(%User{email: "test0@example.com"})
+
+      log =
+        capture_log(fn ->
+          Repo.soft_delete_all(User, log: :info)
+        end)
+
+      assert log =~ "UPDATE"
+      assert log =~ "deleted_at"
     end
   end
 


### PR DESCRIPTION
- Adds optional opts parameter to soft_delete/2, soft_deleteand soft_delete_all/2
- Added tests to cover the new functionality
- Maintaions backward compatibility with existing code
- Enables use of options like 'prefix' for multi-tenant databases
- Updates function documentation with examples showing options usage
- Adds section to README about using options with soft delete functions