### PR TITLE
Chore // Corrected version for next release to 2.1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoSoftDelete.Mixfile do
   def project do
     [
       app: :ecto_soft_delete,
-      version: "2.1.4",
+      version: "2.1.0",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
I accidentally put 2.1.4 - this sets the `mix.exs` to the correct version of 2.1.0.